### PR TITLE
Updated to arkworks 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ark-spartan"
 # sync up with Arkwork's version
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     # author of original Spartan paper and code base 
     # for which this library is modified from
@@ -32,12 +32,12 @@ thiserror = "1.0"
 
 rand_chacha = { version = "0.3.0", default-features = false }
 
-ark-ec = { version = "^0.3.0", default-features = false }
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-std = { version = "^0.3.0", default-features = false }
-ark-serialize =  { version = "^0.3.0", default-features = false, features = [ "derive" ] }
+ark-ec = { version = "^0.4.0", default-features = false }
+ark-ff = { version = "^0.4.0", default-features = false }
+ark-std = { version = "^0.4.0", default-features = false }
+ark-serialize =  { version = "^0.4.0", default-features = false, features = [ "derive" ] }
 
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = [ "curve" ] }
+ark-bls12-381 = { version = "^0.4.0", default-features = false, features = [ "curve" ] }
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/benches/nizk.rs
+++ b/benches/nizk.rs
@@ -9,13 +9,13 @@ extern crate rand;
 extern crate sha3;
 
 use ark_bls12_381::G1Projective;
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use libspartan::{Instance, NIZKGens, NIZK};
 use merlin::Transcript;
 
 use criterion::*;
 
-fn nizk_prove_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
+fn nizk_prove_benchmark<G: CurveGroup>(c: &mut Criterion) {
   for &s in [10, 12, 16].iter() {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("NIZK_prove_benchmark");
@@ -47,7 +47,7 @@ fn nizk_prove_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
   }
 }
 
-fn nizk_verify_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
+fn nizk_verify_benchmark<G: CurveGroup>(c: &mut Criterion) {
   for &s in [10, 12, 16].iter() {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("NIZK_verify_benchmark");

--- a/benches/snark.rs
+++ b/benches/snark.rs
@@ -3,13 +3,13 @@ extern crate libspartan;
 extern crate merlin;
 
 use ark_bls12_381::G1Projective;
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use libspartan::{Instance, SNARKGens, SNARK};
 use merlin::Transcript;
 
 use criterion::*;
 
-fn snark_encode_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
+fn snark_encode_benchmark<G: CurveGroup>(c: &mut Criterion) {
   for s in 10..21 {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("SNARK_encode_benchmark");
@@ -35,7 +35,7 @@ fn snark_encode_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
   }
 }
 
-fn snark_prove_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
+fn snark_prove_benchmark<G: CurveGroup>(c: &mut Criterion) {
   for s in 9..21 {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("SNARK_prove_benchmark");
@@ -74,7 +74,7 @@ fn snark_prove_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
   }
 }
 
-fn snark_verify_benchmark<G: ProjectiveCurve>(c: &mut Criterion) {
+fn snark_verify_benchmark<G: CurveGroup>(c: &mut Criterion) {
   for s in 10..21 {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
     let mut group = c.benchmark_group("SNARK_verify_benchmark");

--- a/profiler/nizk.rs
+++ b/profiler/nizk.rs
@@ -37,7 +37,7 @@ pub fn main() {
     let proof = NIZK::prove(&inst, vars, &inputs, &gens, &mut prover_transcript);
 
     let mut proof_encoded = vec![];
-    proof.serialize(&mut proof_encoded).unwrap();
+    proof.serialize_compressed(&mut proof_encoded).unwrap();
 
     let msg_proof_len = format!("NIZK::proof_compressed_len {:?}", proof_encoded.len());
     print(&msg_proof_len);

--- a/profiler/snark.rs
+++ b/profiler/snark.rs
@@ -47,7 +47,7 @@ pub fn main() {
     );
 
     let mut proof_encoded = vec![];
-    proof.serialize(&mut proof_encoded).unwrap();
+    proof.serialize_compressed(&mut proof_encoded).unwrap();
 
     let msg_proof_len = format!("SNARK::proof_compressed_len {:?}", proof_encoded.len());
     print(&msg_proof_len);

--- a/src/commitments.rs
+++ b/src/commitments.rs
@@ -1,5 +1,5 @@
-use ark_ec::msm::VariableBaseMSM;
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
+use ark_ec::VariableBaseMSM;
 use ark_ff::PrimeField;
 use ark_std::rand::SeedableRng;
 use digest::{ExtendableOutput, Input};
@@ -14,12 +14,12 @@ pub struct MultiCommitGens<G> {
   pub h: G,
 }
 
-impl<G: ProjectiveCurve> MultiCommitGens<G> {
+impl<G: CurveGroup> MultiCommitGens<G> {
   pub fn new(n: usize, label: &[u8]) -> Self {
     let mut shake = Shake256::default();
     shake.input(label);
     let mut buf = vec![];
-    G::prime_subgroup_generator().serialize(&mut buf).unwrap();
+    G::generator().serialize_compressed(&mut buf).unwrap();
     shake.input(buf);
 
     let mut reader = shake.xof_result();
@@ -65,26 +65,26 @@ impl<G: ProjectiveCurve> MultiCommitGens<G> {
   }
 }
 
-pub trait Commitments<G: ProjectiveCurve>: Sized {
+pub trait Commitments<G: CurveGroup>: Sized {
   fn commit(&self, blind: &G::ScalarField, gens_n: &MultiCommitGens<G>) -> G;
   fn batch_commit(inputs: &[Self], blind: &G::ScalarField, gens_n: &MultiCommitGens<G>) -> G;
 }
 
-impl<G: ProjectiveCurve> Commitments<G> for G::ScalarField {
+impl<G: CurveGroup> Commitments<G> for G::ScalarField {
   fn commit(&self, blind: &G::ScalarField, gens_n: &MultiCommitGens<G>) -> G {
     assert_eq!(gens_n.n, 1);
 
-    gens_n.G[0].mul(self.into_repr()) + gens_n.h.mul(blind.into_repr())
+    gens_n.G[0].mul_bigint(self.into_bigint()) + gens_n.h.mul_bigint(blind.into_bigint())
   }
 
   fn batch_commit(inputs: &[Self], blind: &G::ScalarField, gens_n: &MultiCommitGens<G>) -> G {
     assert_eq!(gens_n.n, inputs.len());
 
-    let mut bases = ProjectiveCurve::batch_normalization_into_affine(gens_n.G.as_ref());
-    let mut scalars = inputs.iter().map(|x| x.into_repr()).collect::<Vec<_>>();
+    let mut bases = CurveGroup::normalize_batch(gens_n.G.as_ref());
+    let mut scalars = inputs.to_vec();
     bases.push(gens_n.h.into_affine());
-    scalars.push(blind.into_repr());
+    scalars.push(*blind);
 
-    VariableBaseMSM::multi_scalar_mul(bases.as_ref(), scalars.as_ref())
+    VariableBaseMSM::msm(bases.as_ref(), scalars.as_ref()).unwrap()
   }
 }

--- a/src/commitments.rs
+++ b/src/commitments.rs
@@ -1,6 +1,5 @@
 use ark_ec::CurveGroup;
 use ark_ec::VariableBaseMSM;
-use ark_ff::PrimeField;
 use ark_std::rand::SeedableRng;
 use digest::{ExtendableOutput, Input};
 use rand_chacha::ChaCha20Rng;
@@ -74,7 +73,7 @@ impl<G: CurveGroup> Commitments<G> for G::ScalarField {
   fn commit(&self, blind: &G::ScalarField, gens_n: &MultiCommitGens<G>) -> G {
     assert_eq!(gens_n.n, 1);
 
-    gens_n.G[0].mul_bigint(self.into_bigint()) + gens_n.h.mul_bigint(blind.into_bigint())
+    gens_n.G[0] * self + gens_n.h * blind
   }
 
   fn batch_commit(inputs: &[Self], blind: &G::ScalarField, gens_n: &MultiCommitGens<G>) -> G {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod timer;
 mod transcript;
 mod unipoly;
 
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_serialize::*;
 use core::cmp::max;
@@ -42,7 +42,7 @@ use timer::Timer;
 use transcript::{AppendToTranscript, ProofTranscript};
 
 /// `ComputationCommitment` holds a public preprocessed NP statement (e.g., R1CS)
-pub struct ComputationCommitment<G: ProjectiveCurve> {
+pub struct ComputationCommitment<G: CurveGroup> {
   comm: R1CSCommitment<G>,
 }
 
@@ -257,7 +257,7 @@ pub struct SNARKGens<G> {
   gens_r1cs_eval: R1CSCommitmentGens<G>,
 }
 
-impl<G: ProjectiveCurve> SNARKGens<G> {
+impl<G: CurveGroup> SNARKGens<G> {
   /// Constructs a new `SNARKGens` given the size of the R1CS statement
   /// `num_nz_entries` specifies the maximum number of non-zero entries in any of the three R1CS matrices
   pub fn new(num_cons: usize, num_vars: usize, num_inputs: usize, num_nz_entries: usize) -> Self {
@@ -286,13 +286,13 @@ impl<G: ProjectiveCurve> SNARKGens<G> {
 
 /// `SNARK` holds a proof produced by Spartan SNARK
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug)]
-pub struct SNARK<G: ProjectiveCurve> {
+pub struct SNARK<G: CurveGroup> {
   r1cs_sat_proof: R1CSProof<G>,
   inst_evals: (G::ScalarField, G::ScalarField, G::ScalarField),
   r1cs_eval_proof: R1CSEvalProof<G>,
 }
 
-impl<G: ProjectiveCurve> SNARK<G> {
+impl<G: CurveGroup> SNARK<G> {
   fn protocol_name() -> &'static [u8] {
     b"Spartan SNARK proof"
   }
@@ -359,7 +359,7 @@ impl<G: ProjectiveCurve> SNARK<G> {
       };
 
       let mut proof_encoded = vec![];
-      proof.serialize(&mut proof_encoded).unwrap();
+      proof.serialize_compressed(&mut proof_encoded).unwrap();
 
       Timer::print(&format!("len_r1cs_sat_proof {:?}", proof_encoded.len()));
 
@@ -390,7 +390,7 @@ impl<G: ProjectiveCurve> SNARK<G> {
       );
 
       let mut proof_encoded = vec![];
-      proof.serialize(&mut proof_encoded).unwrap();
+      proof.serialize_compressed(&mut proof_encoded).unwrap();
 
       Timer::print(&format!("len_r1cs_eval_proof {:?}", proof_encoded.len()));
       proof
@@ -457,7 +457,7 @@ pub struct NIZKGens<G> {
   gens_r1cs_sat: R1CSGens<G>,
 }
 
-impl<G: ProjectiveCurve> NIZKGens<G> {
+impl<G: CurveGroup> NIZKGens<G> {
   /// Constructs a new `NIZKGens` given the size of the R1CS statement
   pub fn new(num_cons: usize, num_vars: usize, num_inputs: usize) -> Self {
     let num_vars_padded = {
@@ -475,12 +475,12 @@ impl<G: ProjectiveCurve> NIZKGens<G> {
 
 /// `NIZK` holds a proof produced by Spartan NIZK
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug)]
-pub struct NIZK<G: ProjectiveCurve> {
+pub struct NIZK<G: CurveGroup> {
   r1cs_sat_proof: R1CSProof<G>,
   r: (Vec<G::ScalarField>, Vec<G::ScalarField>),
 }
 
-impl<G: ProjectiveCurve> NIZK<G> {
+impl<G: CurveGroup> NIZK<G> {
   fn protocol_name() -> &'static [u8] {
     b"Spartan NIZK proof"
   }
@@ -528,7 +528,7 @@ impl<G: ProjectiveCurve> NIZK<G> {
       );
 
       let mut proof_encoded = vec![];
-      proof.serialize(&mut proof_encoded).unwrap();
+      proof.serialize_compressed(&mut proof_encoded).unwrap();
 
       Timer::print(&format!("len_r1cs_sat_proof {:?}", proof_encoded.len()));
       (proof, rx, ry)
@@ -598,7 +598,7 @@ mod tests {
   pub fn check_snark() {
     check_snark_helper::<G1Projective>()
   }
-  pub fn check_snark_helper<G: ProjectiveCurve>() {
+  pub fn check_snark_helper<G: CurveGroup>() {
     let num_vars = 256;
     let num_cons = num_vars;
     let num_inputs = 10;
@@ -679,7 +679,7 @@ mod tests {
     test_padded_constraints_helper::<G1Projective>()
   }
 
-  fn test_padded_constraints_helper<G: ProjectiveCurve>() {
+  fn test_padded_constraints_helper<G: CurveGroup>() {
     // parameters of the R1CS instance
     let num_cons = 1;
     let num_vars = 0;

--- a/src/nizk/bullet.rs
+++ b/src/nizk/bullet.rs
@@ -6,7 +6,7 @@
 use super::super::errors::ProofVerifyError;
 use super::super::math::Math;
 use super::super::transcript::ProofTranscript;
-use ark_ec::{msm::VariableBaseMSM, ProjectiveCurve};
+use ark_ec::{CurveGroup, VariableBaseMSM};
 use ark_ff::{Field, PrimeField};
 use ark_serialize::*;
 use ark_std::One;
@@ -14,12 +14,12 @@ use core::iter;
 use merlin::Transcript;
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct BulletReductionProof<G: ProjectiveCurve> {
+pub struct BulletReductionProof<G: CurveGroup> {
   L_vec: Vec<G>,
   R_vec: Vec<G>,
 }
 
-impl<G: ProjectiveCurve> BulletReductionProof<G> {
+impl<G: CurveGroup> BulletReductionProof<G> {
   /// Create an inner-product proof.
   ///
   /// The proof is created with respect to the bases \\(G\\).
@@ -78,7 +78,7 @@ impl<G: ProjectiveCurve> BulletReductionProof<G> {
         .iter()
         .chain(iter::once(&c_L))
         .chain(iter::once(blind_L))
-        .map(|x| x.into_repr())
+        .copied()
         .collect::<Vec<_>>();
 
       let bases = G_R
@@ -88,15 +88,15 @@ impl<G: ProjectiveCurve> BulletReductionProof<G> {
         .copied()
         .collect::<Vec<_>>();
 
-      let bases = G::batch_normalization_into_affine(bases.as_ref());
+      let bases = G::normalize_batch(bases.as_ref());
 
-      let L = VariableBaseMSM::multi_scalar_mul(bases.as_ref(), scalars.as_ref());
+      let L = VariableBaseMSM::msm(bases.as_ref(), scalars.as_ref()).unwrap();
 
       let scalars = a_R
         .iter()
         .chain(iter::once(&c_R))
         .chain(iter::once(blind_R))
-        .map(|x| x.into_repr())
+        .copied()
         .collect::<Vec<_>>();
 
       let bases = G_L
@@ -106,9 +106,9 @@ impl<G: ProjectiveCurve> BulletReductionProof<G> {
         .copied()
         .collect::<Vec<_>>();
 
-      let bases = G::batch_normalization_into_affine(bases.as_ref());
+      let bases = G::normalize_batch(bases.as_ref());
 
-      let R = VariableBaseMSM::multi_scalar_mul(bases.as_ref(), scalars.as_ref());
+      let R = VariableBaseMSM::msm(bases.as_ref(), scalars.as_ref()).unwrap();
 
       <Transcript as ProofTranscript<G>>::append_point(transcript, b"L", &L);
       <Transcript as ProofTranscript<G>>::append_point(transcript, b"R", &R);
@@ -121,7 +121,7 @@ impl<G: ProjectiveCurve> BulletReductionProof<G> {
         a_L[i] = a_L[i] * u + u_inv * a_R[i];
         b_L[i] = b_L[i] * u_inv + u * b_R[i];
 
-        G_L[i] = G_L[i].mul(u_inv.into_repr()) + G_R[i].mul(u.into_repr());
+        G_L[i] = G_L[i].mul(u_inv) + G_R[i].mul(u);
       }
 
       blind_fin = blind_fin + *blind_L * u * u + *blind_R * u_inv * u_inv;
@@ -134,8 +134,7 @@ impl<G: ProjectiveCurve> BulletReductionProof<G> {
       G = G_L;
     }
 
-    let Gamma_hat =
-      G[0].mul(a[0].into_repr()) + Q.mul((a[0] * b[0]).into_repr()) + H.mul(blind_fin.into_repr());
+    let Gamma_hat = G[0].mul(a[0]) + Q.mul(a[0] * b[0]) + H.mul(blind_fin);
 
     (
       BulletReductionProof { L_vec, R_vec },
@@ -227,26 +226,24 @@ impl<G: ProjectiveCurve> BulletReductionProof<G> {
   ) -> Result<(G, G, G::ScalarField), ProofVerifyError> {
     let (u_sq, u_inv_sq, s) = self.verification_scalars(n, transcript)?;
 
-    let group_element = G::batch_normalization_into_affine(G);
-    let scalars = s.iter().map(|x| x.into_repr()).collect::<Vec<_>>();
+    let group_element = G::normalize_batch(G);
 
-    let G_hat = VariableBaseMSM::multi_scalar_mul(group_element.as_ref(), scalars.as_ref());
+    let G_hat = VariableBaseMSM::msm(group_element.as_ref(), s.as_ref()).unwrap();
 
     let a_hat = inner_product(a, &s);
 
-    let bases = G::batch_normalization_into_affine(
+    let bases = G::normalize_batch(
       [self.L_vec.as_slice(), self.R_vec.as_slice(), &[*Gamma]]
         .concat()
         .as_ref(),
     );
     let scalars = u_sq
-      .iter()
-      .chain(u_inv_sq.iter())
-      .chain(iter::once(&G::ScalarField::one()))
-      .map(|x| x.into_repr())
+      .into_iter()
+      .chain(u_inv_sq.into_iter())
+      .chain(iter::once(G::ScalarField::one()))
       .collect::<Vec<_>>();
 
-    let Gamma_hat = VariableBaseMSM::multi_scalar_mul(bases.as_ref(), scalars.as_ref());
+    let Gamma_hat = VariableBaseMSM::msm(bases.as_ref(), scalars.as_ref()).unwrap();
 
     Ok((G_hat, Gamma_hat, a_hat))
   }

--- a/src/nizk/bullet.rs
+++ b/src/nizk/bullet.rs
@@ -121,7 +121,7 @@ impl<G: CurveGroup> BulletReductionProof<G> {
         a_L[i] = a_L[i] * u + u_inv * a_R[i];
         b_L[i] = b_L[i] * u_inv + u * b_R[i];
 
-        G_L[i] = G_L[i].mul(u_inv) + G_R[i].mul(u);
+        G_L[i] = G_L[i] * u_inv + G_R[i] * u;
       }
 
       blind_fin = blind_fin + *blind_L * u * u + *blind_R * u_inv * u_inv;
@@ -134,7 +134,7 @@ impl<G: CurveGroup> BulletReductionProof<G> {
       G = G_L;
     }
 
-    let Gamma_hat = G[0].mul(a[0]) + Q.mul(a[0] * b[0]) + H.mul(blind_fin);
+    let Gamma_hat = G[0] * a[0] + *Q * a[0] * b[0] + *H * blind_fin;
 
     (
       BulletReductionProof { L_vec, R_vec },
@@ -240,7 +240,7 @@ impl<G: CurveGroup> BulletReductionProof<G> {
     let scalars = u_sq
       .into_iter()
       .chain(u_inv_sq.into_iter())
-      .chain(iter::once(G::ScalarField::one()))
+      .chain([G::ScalarField::one()])
       .collect::<Vec<_>>();
 
     let Gamma_hat = VariableBaseMSM::msm(bases.as_ref(), scalars.as_ref()).unwrap();

--- a/src/nizk/mod.rs
+++ b/src/nizk/mod.rs
@@ -4,22 +4,20 @@ use super::errors::ProofVerifyError;
 use super::math::Math;
 use super::random::RandomTape;
 use super::transcript::ProofTranscript;
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use ark_serialize::*;
 use bullet::BulletReductionProof;
 use merlin::Transcript;
 mod bullet;
-use ark_ff::PrimeField;
-use ark_std::Zero;
 
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug)]
-pub struct KnowledgeProof<G: ProjectiveCurve> {
+pub struct KnowledgeProof<G: CurveGroup> {
   alpha: G,
   z1: G::ScalarField,
   z2: G::ScalarField,
 }
 
-impl<G: ProjectiveCurve> KnowledgeProof<G> {
+impl<G: CurveGroup> KnowledgeProof<G> {
   fn protocol_name() -> &'static [u8] {
     b"knowledge proof"
   }
@@ -71,7 +69,7 @@ impl<G: ProjectiveCurve> KnowledgeProof<G> {
     let c = <Transcript as ProofTranscript<G>>::challenge_scalar(transcript, b"c");
 
     let lhs = self.z1.commit(&self.z2, gens_n);
-    let rhs = C.mul(c.into_repr()) + self.alpha;
+    let rhs = C.mul(c) + self.alpha;
 
     if lhs == rhs {
       Ok(())
@@ -82,12 +80,12 @@ impl<G: ProjectiveCurve> KnowledgeProof<G> {
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug)]
-pub struct EqualityProof<G: ProjectiveCurve> {
+pub struct EqualityProof<G: CurveGroup> {
   alpha: G,
   z: G::ScalarField,
 }
 
-impl<G: ProjectiveCurve> EqualityProof<G> {
+impl<G: CurveGroup> EqualityProof<G> {
   fn protocol_name() -> &'static [u8] {
     b"equality proof"
   }
@@ -115,7 +113,7 @@ impl<G: ProjectiveCurve> EqualityProof<G> {
     let C2 = v2.commit(s2, gens_n);
     <Transcript as ProofTranscript<G>>::append_point(transcript, b"C2", &C2);
 
-    let alpha = gens_n.h.mul(r.into_repr());
+    let alpha = gens_n.h.mul(r);
 
     <Transcript as ProofTranscript<G>>::append_point(transcript, b"alpha", &alpha);
 
@@ -146,10 +144,10 @@ impl<G: ProjectiveCurve> EqualityProof<G> {
 
     let rhs = {
       let C = *C1 - *C2;
-      C.mul(c.into_repr()) + self.alpha
+      C.mul(c) + self.alpha
     };
 
-    let lhs = gens_n.h.mul(self.z.into_repr());
+    let lhs = gens_n.h.mul(self.z);
 
     if lhs == rhs {
       Ok(())
@@ -159,55 +157,15 @@ impl<G: ProjectiveCurve> EqualityProof<G> {
   }
 }
 
-#[derive(Debug)]
-pub struct ProductProof<G: ProjectiveCurve> {
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ProductProof<G: CurveGroup> {
   alpha: G,
   beta: G,
   delta: G,
   z: [G::ScalarField; 5],
 }
 
-impl<G: ProjectiveCurve> CanonicalSerialize for ProductProof<G> {
-  fn serialized_size(&self) -> usize {
-    self.alpha.serialized_size() * 3 + self.z[0].serialized_size() * 5
-  }
-
-  fn serialize<W>(&self, mut writer: W) -> Result<(), SerializationError>
-  where
-    W: Write,
-  {
-    self.alpha.serialize(&mut writer)?;
-    self.beta.serialize(&mut writer)?;
-    self.delta.serialize(&mut writer)?;
-    for &e in self.z.iter() {
-      e.serialize(&mut writer)?;
-    }
-    Ok(())
-  }
-}
-
-impl<G: ProjectiveCurve> CanonicalDeserialize for ProductProof<G> {
-  fn deserialize<R>(mut reader: R) -> Result<Self, SerializationError>
-  where
-    R: Read,
-  {
-    let alpha = G::deserialize(&mut reader)?;
-    let beta = G::deserialize(&mut reader)?;
-    let delta = G::deserialize(&mut reader)?;
-    let mut z = [G::ScalarField::zero(); 5];
-    for e in z.iter_mut() {
-      *e = G::ScalarField::deserialize(&mut reader)?;
-    }
-    Ok(Self {
-      alpha,
-      beta,
-      delta,
-      z,
-    })
-  }
-}
-
-impl<G: ProjectiveCurve> ProductProof<G> {
+impl<G: CurveGroup> ProductProof<G> {
   fn protocol_name() -> &'static [u8] {
     b"product proof"
   }
@@ -290,7 +248,7 @@ impl<G: ProjectiveCurve> ProductProof<G> {
     z1: &G::ScalarField,
     z2: &G::ScalarField,
   ) -> bool {
-    let lhs = *P + X.mul(c.into_repr());
+    let lhs = *P + X.mul(c);
     let rhs = z1.commit(z2, gens_n);
 
     lhs == rhs
@@ -347,7 +305,7 @@ impl<G: ProjectiveCurve> ProductProof<G> {
 }
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct DotProductProof<G: ProjectiveCurve> {
+pub struct DotProductProof<G: CurveGroup> {
   delta: G,
   beta: G,
   z: Vec<G::ScalarField>,
@@ -355,7 +313,7 @@ pub struct DotProductProof<G: ProjectiveCurve> {
   z_beta: G::ScalarField,
 }
 
-impl<G: ProjectiveCurve> DotProductProof<G> {
+impl<G: CurveGroup> DotProductProof<G> {
   fn protocol_name() -> &'static [u8] {
     b"dot product proof"
   }
@@ -455,11 +413,11 @@ impl<G: ProjectiveCurve> DotProductProof<G> {
 
     let c = <Transcript as ProofTranscript<G>>::challenge_scalar(transcript, b"c");
 
-    let mut result = Cx.mul(c.into_repr()) + self.delta
-      == Commitments::batch_commit(self.z.as_ref(), &self.z_delta, gens_n);
+    let mut result =
+      Cx.mul(c) + self.delta == Commitments::batch_commit(self.z.as_ref(), &self.z_delta, gens_n);
 
     let dotproduct_z_a = DotProductProof::<G>::compute_dotproduct(&self.z, a);
-    result &= Cy.mul(c.into_repr()) + self.beta == dotproduct_z_a.commit(&self.z_beta, gens_1);
+    result &= Cy.mul(c) + self.beta == dotproduct_z_a.commit(&self.z_beta, gens_1);
 
     if result {
       Ok(())
@@ -475,7 +433,7 @@ pub struct DotProductProofGens<G> {
   pub gens_1: MultiCommitGens<G>,
 }
 
-impl<G: ProjectiveCurve> DotProductProofGens<G> {
+impl<G: CurveGroup> DotProductProofGens<G> {
   pub fn new(n: usize, label: &[u8]) -> Self {
     let (gens_n, gens_1) = MultiCommitGens::new(n + 1, label).split_at(n);
     DotProductProofGens { n, gens_n, gens_1 }
@@ -483,7 +441,7 @@ impl<G: ProjectiveCurve> DotProductProofGens<G> {
 }
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct DotProductProofLog<G: ProjectiveCurve> {
+pub struct DotProductProofLog<G: CurveGroup> {
   bullet_reduction_proof: BulletReductionProof<G>,
   delta: G,
   beta: G,
@@ -491,7 +449,7 @@ pub struct DotProductProofLog<G: ProjectiveCurve> {
   z2: G::ScalarField,
 }
 
-impl<G: ProjectiveCurve> DotProductProofLog<G> {
+impl<G: CurveGroup> DotProductProofLog<G> {
   fn protocol_name() -> &'static [u8] {
     b"dot product proof (log)"
   }
@@ -624,9 +582,8 @@ impl<G: ProjectiveCurve> DotProductProofLog<G> {
     let z1_s = &self.z1;
     let z2_s = &self.z2;
 
-    let lhs = (Gamma_hat.mul(c_s.into_repr()) + beta_s).mul(a_hat_s.into_repr()) + delta_s;
-    let rhs = (g_hat + gens.gens_1.G[0].mul(a_hat_s.into_repr())).mul(z1_s.into_repr())
-      + gens.gens_1.h.mul(z2_s.into_repr());
+    let lhs = (Gamma_hat.mul(c_s) + beta_s).mul(a_hat_s) + delta_s;
+    let rhs = (g_hat + gens.gens_1.G[0].mul(a_hat_s)).mul(z1_s) + gens.gens_1.h.mul(z2_s);
 
     assert_eq!(lhs, rhs);
 
@@ -650,7 +607,7 @@ mod tests {
     check_knowledgeproof_helper::<G1Projective>()
   }
 
-  fn check_knowledgeproof_helper<G: ProjectiveCurve>() {
+  fn check_knowledgeproof_helper<G: CurveGroup>() {
     let mut prng = test_rng();
 
     let gens_1 = MultiCommitGens::<G>::new(1, b"test-knowledgeproof");
@@ -674,7 +631,7 @@ mod tests {
     check_equalityproof_helper::<G1Projective>()
   }
 
-  fn check_equalityproof_helper<G: ProjectiveCurve>() {
+  fn check_equalityproof_helper<G: CurveGroup>() {
     let mut prng = test_rng();
 
     let gens_1 = MultiCommitGens::<G>::new(1, b"test-equalityproof");
@@ -706,7 +663,7 @@ mod tests {
     check_productproof_helper::<G1Projective>()
   }
 
-  fn check_productproof_helper<G: ProjectiveCurve>() {
+  fn check_productproof_helper<G: CurveGroup>() {
     let mut prng = test_rng();
 
     let gens_1 = MultiCommitGens::<G>::new(1, b"test-productproof");
@@ -742,7 +699,7 @@ mod tests {
     check_dotproductproof_helper::<G1Projective>()
   }
 
-  fn check_dotproductproof_helper<G: ProjectiveCurve>() {
+  fn check_dotproductproof_helper<G: CurveGroup>() {
     let mut prng = test_rng();
 
     let n = 1024;
@@ -784,7 +741,7 @@ mod tests {
   fn check_dotproductproof_log() {
     check_dotproductproof_log_helper::<G1Projective>()
   }
-  fn check_dotproductproof_log_helper<G: ProjectiveCurve>() {
+  fn check_dotproductproof_log_helper<G: CurveGroup>() {
     let mut prng = test_rng();
 
     let n = 1024;

--- a/src/nizk/mod.rs
+++ b/src/nizk/mod.rs
@@ -69,7 +69,7 @@ impl<G: CurveGroup> KnowledgeProof<G> {
     let c = <Transcript as ProofTranscript<G>>::challenge_scalar(transcript, b"c");
 
     let lhs = self.z1.commit(&self.z2, gens_n);
-    let rhs = C.mul(c) + self.alpha;
+    let rhs = *C * c + self.alpha;
 
     if lhs == rhs {
       Ok(())
@@ -113,7 +113,7 @@ impl<G: CurveGroup> EqualityProof<G> {
     let C2 = v2.commit(s2, gens_n);
     <Transcript as ProofTranscript<G>>::append_point(transcript, b"C2", &C2);
 
-    let alpha = gens_n.h.mul(r);
+    let alpha = gens_n.h * r;
 
     <Transcript as ProofTranscript<G>>::append_point(transcript, b"alpha", &alpha);
 
@@ -144,10 +144,10 @@ impl<G: CurveGroup> EqualityProof<G> {
 
     let rhs = {
       let C = *C1 - *C2;
-      C.mul(c) + self.alpha
+      C * c + self.alpha
     };
 
-    let lhs = gens_n.h.mul(self.z);
+    let lhs = gens_n.h * self.z;
 
     if lhs == rhs {
       Ok(())
@@ -248,7 +248,7 @@ impl<G: CurveGroup> ProductProof<G> {
     z1: &G::ScalarField,
     z2: &G::ScalarField,
   ) -> bool {
-    let lhs = *P + X.mul(c);
+    let lhs = *P + *X * *c;
     let rhs = z1.commit(z2, gens_n);
 
     lhs == rhs
@@ -414,10 +414,10 @@ impl<G: CurveGroup> DotProductProof<G> {
     let c = <Transcript as ProofTranscript<G>>::challenge_scalar(transcript, b"c");
 
     let mut result =
-      Cx.mul(c) + self.delta == Commitments::batch_commit(self.z.as_ref(), &self.z_delta, gens_n);
+      *Cx * c + self.delta == Commitments::batch_commit(self.z.as_ref(), &self.z_delta, gens_n);
 
     let dotproduct_z_a = DotProductProof::<G>::compute_dotproduct(&self.z, a);
-    result &= Cy.mul(c) + self.beta == dotproduct_z_a.commit(&self.z_beta, gens_1);
+    result &= *Cy * c + self.beta == dotproduct_z_a.commit(&self.z_beta, gens_1);
 
     if result {
       Ok(())
@@ -582,8 +582,8 @@ impl<G: CurveGroup> DotProductProofLog<G> {
     let z1_s = &self.z1;
     let z2_s = &self.z2;
 
-    let lhs = (Gamma_hat.mul(c_s) + beta_s).mul(a_hat_s) + delta_s;
-    let rhs = (g_hat + gens.gens_1.G[0].mul(a_hat_s)).mul(z1_s) + gens.gens_1.h.mul(z2_s);
+    let lhs = (Gamma_hat * c_s + beta_s) * a_hat_s + delta_s;
+    let rhs = (g_hat + gens.gens_1.G[0] * a_hat_s) * z1_s + gens.gens_1.h * z2_s;
 
     assert_eq!(lhs, rhs);
 

--- a/src/product_tree.rs
+++ b/src/product_tree.rs
@@ -4,7 +4,7 @@ use super::dense_mlpoly::EqPolynomial;
 use super::math::Math;
 use super::sumcheck::SumcheckInstanceProof;
 use super::transcript::ProofTranscript;
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_serialize::*;
 use merlin::Transcript;
@@ -129,7 +129,7 @@ impl<F: PrimeField> LayerProof<F> {
     transcript: &mut Transcript,
   ) -> (F, Vec<F>)
   where
-    G: ProjectiveCurve<ScalarField = F>,
+    G: CurveGroup<ScalarField = F>,
   {
     self
       .proof
@@ -156,7 +156,7 @@ impl<F: PrimeField> LayerProofBatched<F> {
     transcript: &mut Transcript,
   ) -> (F, Vec<F>)
   where
-    G: ProjectiveCurve<ScalarField = F>,
+    G: CurveGroup<ScalarField = F>,
   {
     self
       .proof
@@ -180,7 +180,7 @@ impl<F: PrimeField> ProductCircuitEvalProof<F> {
   #![allow(dead_code)]
   pub fn prove<G>(circuit: &mut ProductCircuit<F>, transcript: &mut Transcript) -> (Self, F, Vec<F>)
   where
-    G: ProjectiveCurve<ScalarField = F>,
+    G: CurveGroup<ScalarField = F>,
   {
     let mut proof: Vec<LayerProof<F>> = Vec::new();
     let num_layers = circuit.left_vec.len();
@@ -239,7 +239,7 @@ impl<F: PrimeField> ProductCircuitEvalProof<F> {
 
   pub fn verify<G>(&self, eval: F, len: usize, transcript: &mut Transcript) -> (F, Vec<F>)
   where
-    G: ProjectiveCurve<ScalarField = F>,
+    G: CurveGroup<ScalarField = F>,
   {
     let num_layers = len.log_2() as usize;
     let mut claim = eval;
@@ -288,7 +288,7 @@ impl<F: PrimeField> ProductCircuitEvalProofBatched<F> {
     transcript: &mut Transcript,
   ) -> (Self, Vec<F>)
   where
-    G: ProjectiveCurve<ScalarField = F>,
+    G: CurveGroup<ScalarField = F>,
   {
     assert!(!prod_circuit_vec.is_empty());
 
@@ -446,7 +446,7 @@ impl<F: PrimeField> ProductCircuitEvalProofBatched<F> {
     transcript: &mut Transcript,
   ) -> (Vec<F>, Vec<F>, Vec<F>)
   where
-    G: ProjectiveCurve<ScalarField = F>,
+    G: CurveGroup<ScalarField = F>,
   {
     let num_layers = len.log_2() as usize;
     let mut rand: Vec<F> = Vec::new();

--- a/src/r1csproof.rs
+++ b/src/r1csproof.rs
@@ -12,15 +12,14 @@ use super::sparse_mlpoly::{SparsePolyEntry, SparsePolynomial};
 use super::sumcheck::ZKSumcheckInstanceProof;
 use super::timer::Timer;
 use super::transcript::{AppendToTranscript, ProofTranscript};
-use ark_ec::msm::VariableBaseMSM;
-use ark_ec::ProjectiveCurve;
-use ark_ff::PrimeField;
+use ark_ec::CurveGroup;
+use ark_ec::VariableBaseMSM;
 use ark_serialize::*;
 use ark_std::{One, Zero};
 use merlin::Transcript;
 
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug)]
-pub struct R1CSProof<G: ProjectiveCurve> {
+pub struct R1CSProof<G: CurveGroup> {
   comm_vars: PolyCommitment<G>,
   sc_proof_phase1: ZKSumcheckInstanceProof<G>,
   claims_phase2: (G, G, G, G),
@@ -39,7 +38,7 @@ pub struct R1CSSumcheckGens<G> {
 }
 
 // TODO: fix passing gens_1_ref
-impl<G: ProjectiveCurve> R1CSSumcheckGens<G> {
+impl<G: CurveGroup> R1CSSumcheckGens<G> {
   pub fn new(label: &'static [u8], gens_1_ref: &MultiCommitGens<G>) -> Self {
     let gens_1 = gens_1_ref.clone();
     let gens_3 = MultiCommitGens::new(3, label);
@@ -58,7 +57,7 @@ pub struct R1CSGens<G> {
   gens_pc: PolyCommitmentGens<G>,
 }
 
-impl<G: ProjectiveCurve> R1CSGens<G> {
+impl<G: CurveGroup> R1CSGens<G> {
   pub fn new(label: &'static [u8], _num_cons: usize, num_vars: usize) -> Self {
     let num_poly_vars = num_vars.log_2() as usize;
     let gens_pc = PolyCommitmentGens::new(num_poly_vars, label);
@@ -67,7 +66,7 @@ impl<G: ProjectiveCurve> R1CSGens<G> {
   }
 }
 
-impl<G: ProjectiveCurve> R1CSProof<G> {
+impl<G: CurveGroup> R1CSProof<G> {
   #[allow(clippy::type_complexity)]
   fn prove_phase_one(
     num_rounds: usize,
@@ -437,8 +436,7 @@ impl<G: ProjectiveCurve> R1CSProof<G> {
     let taus_bound_rx: G::ScalarField = (0..rx.len())
       .map(|i| rx[i] * tau[i] + (G::ScalarField::one() - rx[i]) * (G::ScalarField::one() - tau[i]))
       .product();
-    let expected_claim_post_phase1 =
-      (*comm_prod_Az_Bz_claims - *comm_Cz_claim).mul(taus_bound_rx.into_repr());
+    let expected_claim_post_phase1 = (*comm_prod_Az_Bz_claims - *comm_Cz_claim).mul(taus_bound_rx);
 
     // verify proof that expected_claim_post_phase1 == claim_post_phase1
     self.proof_eq_sc_phase1.verify(
@@ -454,13 +452,12 @@ impl<G: ProjectiveCurve> R1CSProof<G> {
     let r_C = <Transcript as ProofTranscript<G>>::challenge_scalar(transcript, b"challenege_Cz");
 
     // r_A * comm_Az_claim + r_B * comm_Bz_claim + r_C * comm_Cz_claim;
-    let scalars = vec![r_A.into_repr(), r_B.into_repr(), r_C.into_repr()];
+    let scalars = vec![r_A, r_B, r_C];
     let bases = vec![*comm_Az_claim, *comm_Bz_claim, *comm_Cz_claim];
 
-    let bases_affine = G::batch_normalization_into_affine(bases.as_ref());
+    let bases_affine = G::normalize_batch(bases.as_ref());
 
-    let comm_claim_phase2 =
-      VariableBaseMSM::multi_scalar_mul(bases_affine.as_ref(), scalars.as_ref());
+    let comm_claim_phase2 = VariableBaseMSM::msm(bases_affine.as_ref(), scalars.as_ref()).unwrap();
 
     // verify the joint claim with a sum-check protocol
     let (comm_claim_post_phase2, ry) = self.sc_proof_phase2.verify(
@@ -494,10 +491,7 @@ impl<G: ProjectiveCurve> R1CSProof<G> {
     };
 
     // compute commitment to eval_Z_at_ry = (F::one() - ry[0]) * self.eval_vars_at_ry + ry[0] * poly_input_eval
-    let scalars = vec![
-      (G::ScalarField::one() - ry[0]).into_repr(),
-      ry[0].into_repr(),
-    ];
+    let scalars = vec![(G::ScalarField::one() - ry[0]), ry[0]];
 
     let bases = vec![
       self.comm_vars_at_ry.into_affine(),
@@ -506,12 +500,12 @@ impl<G: ProjectiveCurve> R1CSProof<G> {
         .into_affine(),
     ];
 
-    let comm_eval_Z_at_ry = VariableBaseMSM::multi_scalar_mul(bases.as_ref(), scalars.as_ref());
+    let comm_eval_Z_at_ry: G = VariableBaseMSM::msm(bases.as_ref(), scalars.as_ref()).unwrap();
 
     // perform the final check in the second sum-check protocol
     let (eval_A_r, eval_B_r, eval_C_r) = evals;
     let expected_claim_post_phase2 =
-      comm_eval_Z_at_ry.mul((r_A * eval_A_r + r_B * eval_B_r + r_C * eval_C_r).into_repr());
+      comm_eval_Z_at_ry.mul(r_A * eval_A_r + r_B * eval_B_r + r_C * eval_C_r);
 
     // verify proof that expected_claim_post_phase1 == claim_post_phase1
     self.proof_eq_sc_phase2.verify(
@@ -530,6 +524,7 @@ mod tests {
   use super::*;
   use ark_bls12_381::Fr;
   use ark_bls12_381::G1Projective;
+  use ark_ff::PrimeField;
   use ark_std::test_rng;
 
   fn produce_tiny_r1cs<F: PrimeField>() -> (R1CSInstance<F>, Vec<F>, Vec<F>) {
@@ -616,7 +611,7 @@ mod tests {
     check_r1cs_proof_helper::<G1Projective>()
   }
 
-  fn check_r1cs_proof_helper<G: ProjectiveCurve>() {
+  fn check_r1cs_proof_helper<G: CurveGroup>() {
     let num_vars = 1024;
     let num_cons = num_vars;
     let num_inputs = 10;

--- a/src/r1csproof.rs
+++ b/src/r1csproof.rs
@@ -436,7 +436,7 @@ impl<G: CurveGroup> R1CSProof<G> {
     let taus_bound_rx: G::ScalarField = (0..rx.len())
       .map(|i| rx[i] * tau[i] + (G::ScalarField::one() - rx[i]) * (G::ScalarField::one() - tau[i]))
       .product();
-    let expected_claim_post_phase1 = (*comm_prod_Az_Bz_claims - *comm_Cz_claim).mul(taus_bound_rx);
+    let expected_claim_post_phase1 = (*comm_prod_Az_Bz_claims - *comm_Cz_claim) * taus_bound_rx;
 
     // verify proof that expected_claim_post_phase1 == claim_post_phase1
     self.proof_eq_sc_phase1.verify(
@@ -505,7 +505,7 @@ impl<G: CurveGroup> R1CSProof<G> {
     // perform the final check in the second sum-check protocol
     let (eval_A_r, eval_B_r, eval_C_r) = evals;
     let expected_claim_post_phase2 =
-      comm_eval_Z_at_ry.mul(r_A * eval_A_r + r_B * eval_B_r + r_C * eval_C_r);
+      comm_eval_Z_at_ry * (r_A * eval_A_r + r_B * eval_B_r + r_C * eval_C_r);
 
     // verify proof that expected_claim_post_phase1 == claim_post_phase1
     self.proof_eq_sc_phase2.verify(

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use super::transcript::ProofTranscript;
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use ark_ff::UniformRand;
 use ark_std::test_rng;
 use merlin::Transcript;
@@ -11,7 +11,7 @@ pub struct RandomTape<G> {
   phantom: PhantomData<G>,
 }
 
-impl<G: ProjectiveCurve> RandomTape<G> {
+impl<G: CurveGroup> RandomTape<G> {
   pub fn new(name: &'static [u8]) -> Self {
     let tape = {
       let mut prng = test_rng();

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -1,9 +1,9 @@
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
 use merlin::Transcript;
 
-pub trait ProofTranscript<G: ProjectiveCurve> {
+pub trait ProofTranscript<G: CurveGroup> {
   fn append_protocol_name(&mut self, protocol_name: &'static [u8]);
   fn append_scalar(&mut self, label: &'static [u8], scalar: &G::ScalarField);
   fn append_scalars(&mut self, label: &'static [u8], scalars: &[G::ScalarField]);
@@ -13,14 +13,14 @@ pub trait ProofTranscript<G: ProjectiveCurve> {
   fn challenge_vector(&mut self, label: &'static [u8], len: usize) -> Vec<G::ScalarField>;
 }
 
-impl<G: ProjectiveCurve> ProofTranscript<G> for Transcript {
+impl<G: CurveGroup> ProofTranscript<G> for Transcript {
   fn append_protocol_name(&mut self, protocol_name: &'static [u8]) {
     self.append_message(b"protocol-name", protocol_name);
   }
 
   fn append_scalar(&mut self, label: &'static [u8], scalar: &G::ScalarField) {
     let mut buf = vec![];
-    scalar.serialize(&mut buf).unwrap();
+    scalar.serialize_compressed(&mut buf).unwrap();
     self.append_message(label, &buf);
   }
 
@@ -34,7 +34,7 @@ impl<G: ProjectiveCurve> ProofTranscript<G> for Transcript {
 
   fn append_point(&mut self, label: &'static [u8], point: &G) {
     let mut buf = vec![];
-    point.serialize(&mut buf).unwrap();
+    point.serialize_compressed(&mut buf).unwrap();
     self.append_message(label, &buf);
   }
 
@@ -59,17 +59,17 @@ impl<G: ProjectiveCurve> ProofTranscript<G> for Transcript {
   }
 }
 
-pub trait AppendToTranscript<G: ProjectiveCurve> {
+pub trait AppendToTranscript<G: CurveGroup> {
   fn append_to_transcript(&self, label: &'static [u8], transcript: &mut Transcript);
 }
 
-// // impl<G:ProjectiveCurve> AppendToTranscript<G> for G::ScalarField {
+// // impl<G:CurveGroup> AppendToTranscript<G> for G::ScalarField {
 // //   fn append_to_transcript(&self, label: &'static [u8], transcript: &mut Transcript) {
 // //     transcript.append_scalar(label, self);
 // //   }
 // // }
 
-// impl<G:ProjectiveCurve> AppendToTranscript<G> for [G::ScalarField] {
+// impl<G:CurveGroup> AppendToTranscript<G> for [G::ScalarField] {
 //   fn append_to_transcript(&self, label: &'static [u8], transcript: &mut Transcript) {
 //     transcript.append_message(label, b"begin_append_vector");
 //     for item in self {
@@ -79,7 +79,7 @@ pub trait AppendToTranscript<G: ProjectiveCurve> {
 //   }
 // }
 
-// impl<G:ProjectiveCurve> AppendToTranscript<G> for G {
+// impl<G:CurveGroup> AppendToTranscript<G> for G {
 //   fn append_to_transcript(&self, label: &'static [u8], transcript: &mut Transcript) {
 //     transcript.append_point(label, self);
 //   }

--- a/src/unipoly.rs
+++ b/src/unipoly.rs
@@ -1,6 +1,6 @@
 use super::commitments::{Commitments, MultiCommitGens};
 use super::transcript::{AppendToTranscript, ProofTranscript};
-use ark_ec::ProjectiveCurve;
+use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_serialize::*;
 use merlin::Transcript;
@@ -87,11 +87,7 @@ impl<F: PrimeField> UniPoly<F> {
     }
   }
 
-  pub fn commit<G: ProjectiveCurve<ScalarField = F>>(
-    &self,
-    gens: &MultiCommitGens<G>,
-    blind: &F,
-  ) -> G {
+  pub fn commit<G: CurveGroup<ScalarField = F>>(&self, gens: &MultiCommitGens<G>, blind: &F) -> G {
     Commitments::batch_commit(&self.coeffs, blind, gens)
   }
 }
@@ -113,7 +109,7 @@ impl<F: PrimeField> CompressedUniPoly<F> {
   }
 }
 
-impl<G: ProjectiveCurve> AppendToTranscript<G> for UniPoly<G::ScalarField> {
+impl<G: CurveGroup> AppendToTranscript<G> for UniPoly<G::ScalarField> {
   fn append_to_transcript(&self, label: &'static [u8], transcript: &mut Transcript) {
     transcript.append_message(label, b"UniPoly_begin");
     for i in 0..self.coeffs.len() {


### PR DESCRIPTION
This updates ark-spartan to arkworks 0.4.

There are two main points were I had to make a choice which you might want to change:
1. How to handle serialization. I defaulted it to serialize_compressed, however it would also be possible to pass a ark_serialize::Compress variant every time.
2. How to handle the Result return value of VariableBaseMSM::msm. I simply called Result::unwrap(), but there are nicer ways to handle this if necessary.