### PR TITLE
Docs improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Finally, we provide an example that specifies a custom R1CS instance instead of 
 
   // R1CS is a set of three sparse matrices A B C, where is a row for every 
   // constraint and a column for every entry in z = (vars, 1, inputs)
-  // An R1CS instance is satisfiable iff:
+  // An R1CS instance is satisfiable if:
   // Az \circ Bz = Cz, where z = (vars, 1, inputs)
 
   // constraint 0 entries in (A,B,C)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl<F: PrimeField> Assignment<F> {
 
   /// pads Assignment to the specified length
   fn pad(&self, len: usize) -> VarsAssignment<F> {
-    // check that the new length is higher than current length
+    // check that the new length is higher than the current length
     assert!(len > self.assignment.len());
 
     let padded_assignment = {

--- a/src/nizk/bullet.rs
+++ b/src/nizk/bullet.rs
@@ -212,7 +212,7 @@ impl<G: CurveGroup> BulletReductionProof<G> {
     Ok((challenges_sq, challenges_inv_sq, s))
   }
 
-  /// This method is for testing that proof generation work,
+  /// This method is for testing that proof generation works,
   /// but for efficiency the actual protocols would use `verification_scalars`
   /// method to combine inner product verification with other checks
   /// in a single multiscalar multiplication.

--- a/src/sumcheck.rs
+++ b/src/sumcheck.rs
@@ -245,7 +245,7 @@ impl<F: PrimeField> SumcheckInstanceProof<F> {
         <Transcript as ProofTranscript<G>>::challenge_scalar(transcript, b"challenge_nextround");
 
       r.push(r_j);
-      // bound all tables to the verifier's challenege
+      // bound all tables to the verifier's challenge
       poly_A.bound_poly_var_top(&r_j);
       poly_B.bound_poly_var_top(&r_j);
       poly_C.bound_poly_var_top(&r_j);


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.